### PR TITLE
Build for ARM64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,7 @@ jobs:
 
       - name: Build
         run: |
+          rustup target add aarch64-apple-darwin
           cargo build --profile release --target aarch64-apple-darwin
 
       - name: Archive

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,9 @@ name: build
 on:
   push:
     branches: [main]
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build:
@@ -13,7 +16,7 @@ jobs:
 
       - name: Build
         run: |
-          cargo build --profile release
+          cargo build --profile release --target aarch64-apple-darwin
 
       - name: Archive
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Archive
         run: |
-          tar -czvf softnet.tar.gz -C target/release softnet
+          tar -czvf softnet.tar.gz -C target/aarch64-apple-darwin/release softnet
 
       - name: Upload archive
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
`cargo build` builds by default with target of the current execution environment, which in Github Actions is `x86_64-apple-darwin`.